### PR TITLE
Make PR workflow run on pull request target

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
This is a leftover from #2 . It should also fix the current dependabot issues.