### PR TITLE
Prepare for initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial support for the Oryx [ORX-10GS-51S5M-C](https://www.flir.com/products/oryx-10gige/?model=ORX-10GS-51S5M-C&vertical=machine+vision&segment=iis) 10GigE camera ([#18](https://github.com/acquire-project/acquire-driver-spinnaker/pull/18))
+- Initial support for the Blackfly [BFLY-U3-23S6M-C](https://www.flir.com/products/blackfly-usb3/?model=BFLY-U3-23S6M-C&vertical=machine+vision&segment=iis) USB3 camera ([#4](https://github.com/acquire-project/acquire-driver-spinnaker/pull/4)).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,80 @@
-# Acquire Driver for Spinnaker
+# Acquire driver for Spinnaker
 
-This is an acquire driver that supports some Teledyne FLIR cameras using the Spinnaker SDK.
+This is an Acquire driver that supports some Teledyne FLIR cameras using the Spinnaker SDK.
 
-## Supported devices
+## Usage
 
-### Camera
+The intended way to use this library is as part of the [acquire-imaging](https://github.com/acquire-project/acquire-python)
+Python package, which also includes Acquire's runtime as well as other drivers.
+
+That package can be installed using the following command in an environment with Python and `pip`.
+
+```
+python -m pip install acquire-imaging
+```
+
+### Prerequisites
+
+Before using this driver you must install the [Spinnaker SDK](https://www.flir.com/products/spinnaker-sdk/?vertical=machine+vision&segment=iis).
+This driver is built against version 3.1.0.79 of the SDK and you should install exactly the same version.
+
+### Supported cameras
+
+The following cameras have been tested using this driver.
 
 - [Blackfly USB3: BFLY-U3-23S6M-C](https://www.flir.com/products/blackfly-usb3/?model=BFLY-U3-23S6M-C&vertical=machine+vision&segment=iis)
 - [Oryx 10GigE: ORX-10GS-51S5M-C](https://www.flir.com/products/oryx-10gige/?model=ORX-10GS-51S5M-C&vertical=machine+vision&segment=iis)
+
+### Supported operating systems
+
+Windows is the primary usage target.
+But both Windows and macOS are currently supported for development purposes.
+
+## Development
+
+We welcome contributors. The following will help you get started building the code.
+
+### Environment
+
+Requires
+
+- CMake 3.13+ ([download page](https://cmake.org/download/) or via
+  [chocolatey](https://community.chocolatey.org/packages/cmake)).
+- A C++20 compiler (Microsoft Visual Studio Community [download
+  page](https://visualstudio.microsoft.com/downloads/), or clang).
+
+
+### Configure
+
+From the repository root, run the following commands to configure the CMake build files.
+
+```
+mkdir build
+cd build
+cmake ..
+```
+
+### Build
+
+After configuration, run the following command to build the library and tests.
+
+```
+cmake --build .
+```
+
+### Test
+
+After building the default debug configuration, run the following command to run all the tests using CTest.
+
+```
+ctest -C Debug
+```
+
+You will need all supported cameras connected to the device that you're testing on for all tests to pass.
+
+If you only want to run a subset of the tests you can use CTest's `-R` option to specify a pattern to match against.
+For example, if you only want to run the oryx tests, run the following command.
+
+```
+ctest -C Debug -R oryx
+```

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ We welcome contributors. The following will help you get started building the co
 
 Requires
 
-- CMake 3.13+ ([download page](https://cmake.org/download/) or via
-  [chocolatey](https://community.chocolatey.org/packages/cmake)).
-- A C++20 compiler (Microsoft Visual Studio Community [download
-  page](https://visualstudio.microsoft.com/downloads/), or clang).
+- CMake 3.13+ from its [download page](https://cmake.org/download/), or via
+  [chocolatey](https://community.chocolatey.org/packages/cmake) or [homebrew](https://formulae.brew.sh/formula/cmake).
+- A C++20 compiler such as [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/) or [Clang](https://clang.llvm.org/).
 
 
 ### Configure

--- a/src/spinnaker.cpp
+++ b/src/spinnaker.cpp
@@ -1134,6 +1134,12 @@ SpinnakerDriver::SpinnakerDriver()
   },
   system_(Spinnaker::System::GetInstance())
 {
+    Spinnaker::LibraryVersion version = system_->GetLibraryVersion();
+    LOG("Spinnaker version %d.%d.%d.%d",
+        version.major,
+        version.minor,
+        version.type,
+        version.build);
 }
 
 SpinnakerDriver::~SpinnakerDriver()


### PR DESCRIPTION
This makes some updates to prepare for the first release of this driver. Specifically it

- adds a changelog with the unreleased major features included so far;
- updates the README to include important installation, usage, and development instructions;
- logs the spinnaker version on driver construction to help with debugging version incompatibility issues.

Note that it does not actually create a release yet. Instead I plan to create a PR that only modifies the CHANGELOG, then merge that into a single commit with an associated version tag.

Partially addresses #31 