### PR TITLE
Update changelog for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.1.0](https://github.com/acquire-project/acquire-driver-spinnaker/tree/v0.1.0) - 2023-09-29
 
 ### Added
 


### PR DESCRIPTION
This moves currently unreleased changes into the 0.1.0 section in the changelog.

Partially addresses #31 