### PR TITLE
restore original trigger mode when stopping

### DIFF
--- a/src/spinnaker.cpp
+++ b/src/spinnaker.cpp
@@ -936,7 +936,9 @@ SpinnakerCamera::stop()
     // Disable the current trigger to prevent an effective deadlock between
     // EndAcquisition and GetNextFrame that is awaiting a trigger.
     if (IsWritable(camera_->TriggerMode)) {
+        auto mode = camera_->TriggerMode.ToString();
         camera_->TriggerMode = genicam_off;
+        camera_->TriggerMode = mode;
     }
     // Could possibly use camera_->IsStreaming instead, but the Spinnaker
     // docs are not clear enough about what that means. It's critical


### PR DESCRIPTION
This resolves a problem encountered while trying to use software triggering. Configuring initially enables the software trigger, setting `TriggerMode` to on. @nenada encountered this while testing on acquire-micromanager.

When stopping, `TriggerMode` was set to `off`.

Later when `get()` queries the trigger state, it finds the trigger mode off and returns a configuration with all triggering disabled.

This PR, resolves the issue by changing the logic in `stop()`. The mode is toggled off, and then restored to it's original value. 